### PR TITLE
[Hib-33882] Enable host by default

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -8,4 +8,7 @@ import { hiber3DVitePlugin } from "@hiber3d/web/vite-plugin";
 export default defineConfig({
   plugins: [react(), tsconfigPaths(), tailwindcss(), hiber3DVitePlugin()],
   publicDir: "assets",
+  server: {
+    host: true,
+  },
 });


### PR DESCRIPTION
https://favro.com/organization/2b8080a1df85029e334a92f1/40f80e627b5eb9185957d78e?card=Hib-33882

Running `npm run dev` will add `host` by default so that qr code popup will be available