### PR TITLE
[HIB-34003] Add git to list of scoop packages to install in Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,11 @@ Install via [HomeBrew](https://brew.sh/)
 
 Install via [Scoop](https://scoop.sh/)
 
-`scoop install cmake ccache ninja git-lfs nvm`
+`scoop install cmake ccache ninja git git-lfs nvm`
 
 > Note: We recommend installing node via nvm
 
-clang-format is not available in `scoop`
+(clang-format is not available in `scoop`)
 
 ## Getting started
 
@@ -55,3 +55,4 @@ If you only want to compile the C++ code you can run:
 - WebGL only:
   - `npm run compile:webgl`
   - `npm run compile:webgl:release`
+  


### PR DESCRIPTION
`scoop install git` also installs `sh.exe` in `scoop\shims`. Without this, Emscripten will complain that it can't find `sh` when you run `npm run compile`.