### PR TITLE
[HIB-34007] Added git-lfs commands to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,13 @@ clang-format is not available in `scoop`
 
 ## Getting started
 
-From the root of the project, run
+Unless you have used `git lfs` before, it needs to be initialized now:
+
+1. `git-lfs install`
+1. `git-lfs fetch`
+1. `git-lfs checkout`
+
+Next, from the root of the project, run
 
 1. `npm run compile` (See below for options)
 1. `npm install`


### PR DESCRIPTION
Without these commands, the GLB files in the cloned repo will just be plain-text files containing links instead of the actual (binary file) GLBs.